### PR TITLE
Add config to enable CPU usage tracking on Binder

### DIFF
--- a/jupyter_config.json
+++ b/jupyter_config.json
@@ -1,0 +1,5 @@
+{
+  "ResourceUseDisplay": {
+    "track_cpu_percent": true
+  }
+}


### PR DESCRIPTION
`track_cpu_percent` must be enabled to be able to display the CPU usage.