### PR TITLE
Update Binder to use conda packages

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,4 +5,5 @@ dependencies:
 - python=3
 - jupyterlab=3
 - jupyter-resource-usage=0.5
+- jupyterlab-system-monitor=0.8
 - nodejs

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,0 @@
-set -xe
-
-jupyter labextension install jupyterlab-topbar-extension@0.5.0 \
-                             jupyterlab-system-monitor@0.6.0


### PR DESCRIPTION
Since the package is now available on conda.

Testing with:

https://mybinder.org/v2/gh/jtpio/jupyterlab-system-monitor/binder?urlpath=lab