### PR TITLE
Scale CPU utilization chart to available CPUs

### DIFF
--- a/packages/system-monitor-base/src/cpuView.tsx
+++ b/packages/system-monitor-base/src/cpuView.tsx
@@ -20,8 +20,10 @@ const CpuViewComponent = ({
   const [values, setValues] = useState([]);
 
   const update = (): void => {
-    const { currentCpuPercent } = model;
-    const newValues = model.values.map((value) => value.cpuPercent);
+    const { cpuLimit, currentCpuPercent } = model;
+    const newValues = model.values.map((value) =>
+      Math.min(1, value.cpuPercent / cpuLimit)
+    );
     const newText = `${(currentCpuPercent * 100).toFixed(0)}%`;
     setText(newText);
     setValues(newValues);

--- a/packages/system-monitor-base/src/model.ts
+++ b/packages/system-monitor-base/src/model.ts
@@ -54,6 +54,7 @@ export namespace ResourceUsage {
           this._cpuAvailable = false;
           this._currentMemory = 0;
           this._memoryLimit = null;
+          this._cpuLimit = null;
           this._units = 'B';
 
           if (oldMemoryAvailable || oldCpuAvailable) {
@@ -98,6 +99,13 @@ export namespace ResourceUsage {
      */
     get memoryLimit(): number | null {
       return this._memoryLimit;
+    }
+
+    /**
+     * The current cpu limit, or null if not specified.
+     */
+    get cpuLimit(): number | null {
+      return this._cpuLimit;
     }
 
     /**
@@ -167,10 +175,9 @@ export namespace ResourceUsage {
         : null;
 
       const cpuPercent = value.cpu_percent;
+      this._cpuLimit = value.limits.cpu ? value.limits.cpu.cpu : 1;
       this._cpuAvailable = cpuPercent !== undefined;
-      this._currentCpuPercent = this._cpuAvailable
-        ? Math.min(1, cpuPercent / 100)
-        : 0;
+      this._currentCpuPercent = this._cpuAvailable ? cpuPercent / 100 : 0;
 
       this._values.push({ memoryPercent, cpuPercent: this._currentCpuPercent });
       this._values.shift();
@@ -182,6 +189,7 @@ export namespace ResourceUsage {
     private _currentMemory = 0;
     private _currentCpuPercent = 0;
     private _memoryLimit: number | null = null;
+    private _cpuLimit: number | null = null;
     private _poll: Poll<Private.IMetricRequestResult | null>;
     private _units: MemoryUnit = 'B';
     private _changed = new Signal<this, void>(this);


### PR DESCRIPTION
This PR scales the chart of CPU utilization respectively to the number of available CPUs.

For example with total 2 CPUs and total usage of one core, the percentage will be 100%, but the chart will show 50% of the utilization: 
![image](https://user-images.githubusercontent.com/4659069/139075036-92f1506a-e89f-45ae-bb7e-0658f158c842.png)

With 2 CPUs and total usage of 2 cores, percentage will show 200% and full utilization:
![image](https://user-images.githubusercontent.com/4659069/139075269-569f3648-29f9-457d-9eff-1d634a888966.png)


Fixes #38 